### PR TITLE
Encode PlayerID as UInt8Array for audio messages

### DIFF
--- a/ws-util.js
+++ b/ws-util.js
@@ -31,29 +31,17 @@ export const encodeMessage = parts => {
 export const encodeAudioMessage = (method, id, type, timestamp, data) => {
   let index = 0;
 
-  // id is a 5-character string
-  // convert to UTF-8 encode as a UInt8Array
-  const idUint8Array = textEncoder.encode(id);
-  console.log('player id byte length is', idUint8Array.byteLength);
-
   encodedMessageDataView.setUint32(index, method, true);
   index += Uint32Array.BYTES_PER_ELEMENT;
-
   encodedMessageDataView.setUint32(index, type === 'key' ? 0 : 1, true);
   index += Uint32Array.BYTES_PER_ELEMENT;
-
   encodedMessageDataView.setFloat32(index, timestamp, true);
   index += Float32Array.BYTES_PER_ELEMENT;
-
   encodedMessageDataView.setUint32(index, data.byteLength, true);
   index += Uint32Array.BYTES_PER_ELEMENT;
-
-  encodedMessageDataView.setUint32(index, idUint8Array.byteLength, true);
-  index += Uint32Array.BYTES_PER_ELEMENT;
-
-  encodedMessageUint8Array.set(idUint8Array, index);
-  index += idUint8Array.byteLength;
-
+  const idEncoded = textEncoder.encode(id);
+  encodedMessageUint8Array.set(idEncoded, index);
+  index += idEncoded.byteLength;
   encodedMessageUint8Array.set(data, index);
   index += data.byteLength;
 

--- a/ws-util.js
+++ b/ws-util.js
@@ -30,7 +30,6 @@ export const encodeMessage = parts => {
 };
 export const encodeAudioMessage = (method, id, type, timestamp, data) => {
   let index = 0;
-
   encodedMessageDataView.setUint32(index, method, true);
   index += Uint32Array.BYTES_PER_ELEMENT;
   encodedMessageDataView.setUint32(index, type === 'key' ? 0 : 1, true);
@@ -44,7 +43,6 @@ export const encodeAudioMessage = (method, id, type, timestamp, data) => {
   index += idEncoded.byteLength;
   encodedMessageUint8Array.set(data, index);
   index += data.byteLength;
-
   return new Uint8Array(encodedMessageUint8Array.buffer, encodedMessageUint8Array.byteOffset, index);
 };
 export const encodePoseMessage = (method, id, p, q, s, extraUint8ArrayFull, extraUint8ArrayByteLength) => {

--- a/ws-util.js
+++ b/ws-util.js
@@ -30,18 +30,33 @@ export const encodeMessage = parts => {
 };
 export const encodeAudioMessage = (method, id, type, timestamp, data) => {
   let index = 0;
+
+  // id is a 5-character string
+  // convert to UTF-8 encode as a UInt8Array
+  const idUint8Array = textEncoder.encode(id);
+  console.log('player id byte length is', idUint8Array.byteLength);
+
   encodedMessageDataView.setUint32(index, method, true);
   index += Uint32Array.BYTES_PER_ELEMENT;
-  encodedMessageDataView.setUint32(index, id, true);
-  index += Uint32Array.BYTES_PER_ELEMENT;
+
   encodedMessageDataView.setUint32(index, type === 'key' ? 0 : 1, true);
   index += Uint32Array.BYTES_PER_ELEMENT;
+
   encodedMessageDataView.setFloat32(index, timestamp, true);
   index += Float32Array.BYTES_PER_ELEMENT;
+
   encodedMessageDataView.setUint32(index, data.byteLength, true);
   index += Uint32Array.BYTES_PER_ELEMENT;
+
+  encodedMessageDataView.setUint32(index, idUint8Array.byteLength, true);
+  index += Uint32Array.BYTES_PER_ELEMENT;
+
+  encodedMessageUint8Array.set(idUint8Array, index);
+  index += idUint8Array.byteLength;
+
   encodedMessageUint8Array.set(data, index);
   index += data.byteLength;
+
   return new Uint8Array(encodedMessageUint8Array.buffer, encodedMessageUint8Array.byteOffset, index);
 };
 export const encodePoseMessage = (method, id, p, q, s, extraUint8ArrayFull, extraUint8ArrayByteLength) => {

--- a/wsrtc.js
+++ b/wsrtc.js
@@ -145,10 +145,9 @@ class WSRTC extends EventTarget {
           const type = dataView.getUint32(Uint32Array.BYTES_PER_ELEMENT, true) === 0 ? 'key' : 'delta';
           const timestamp = dataView.getFloat32(2*Uint32Array.BYTES_PER_ELEMENT, true);
           const byteLength = dataView.getUint32(3*Uint32Array.BYTES_PER_ELEMENT, true);
-          const playerIdByteLength = dataView.getUint32(4*Uint32Array.BYTES_PER_ELEMENT, true);
-          const playerIdData = new Uint8Array(e.data, 5 * Uint32Array.BYTES_PER_ELEMENT, playerIdByteLength);
+          const playerIdData = new Uint8Array(e.data, 4*Uint32Array.BYTES_PER_ELEMENT, 5);
           const playerId = String.fromCharCode.apply(null, playerIdData);
-          const data = new Uint8Array(e.data, 5 * Uint32Array.BYTES_PER_ELEMENT + playerIdByteLength, byteLength);
+          const data = new Uint8Array(e.data, 4 * Uint32Array.BYTES_PER_ELEMENT + 5, byteLength);
 
         // convert the UInt8Array of characters to a string
           const encodedAudioChunk = new WsEncodedAudioChunk({
@@ -309,7 +308,6 @@ class WSRTC extends EventTarget {
     this.audioReader = audioReader;
     
     const muxAndSend = encodedChunk => {
-      console.log('sending audio chunk')
       const {type, timestamp} = encodedChunk;
       const data = getEncodedAudioChunkBuffer(encodedChunk);
       this.sendAudioMessage(

--- a/wsrtc.js
+++ b/wsrtc.js
@@ -149,7 +149,6 @@ class WSRTC extends EventTarget {
           const playerId = String.fromCharCode.apply(null, playerIdData);
           const data = new Uint8Array(e.data, 4 * Uint32Array.BYTES_PER_ELEMENT + 5, byteLength);
 
-        // convert the UInt8Array of characters to a string
           const encodedAudioChunk = new WsEncodedAudioChunk({
             type: 'key', // XXX: hack! when this is 'delta', you get Uncaught DOMException: Failed to execute 'decode' on 'AudioDecoder': A key frame is required after configure() or flush().
             timestamp,
@@ -159,7 +158,7 @@ class WSRTC extends EventTarget {
           this.dispatchEvent(
             new MessageEvent('audio', {
               data: {
-                playerId: playerId,
+                playerId,
                 data: encodedAudioChunk
               },
             })


### PR DESCRIPTION
In the original implementation, player IDs were Float32s. In my updated implementation, we added a playerIdInt field which was computed and sent with audio messages. This might have mild performance benefits but also means another field that needs to be updated and stored.

This PR instead converts the 5-char playerId into a uint8 array and packs that before the audio data buffer.